### PR TITLE
fix: make errors(raised during loading exportedRule) wrapped in ErrorsInModule

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -16,7 +16,7 @@
     "tasks": {
         "coverage": "rm -rf ./cov && deno test --allow-read --parallel --coverage=cov && deno coverage --detailed ./cov && rm -rf ./cov",
         "coverage-list": "rm -rf ./cov && deno test --allow-read --parallel --coverage=cov && deno coverage ./cov && rm -rf ./cov",
-        "test": "deno run -A npm:madge --circular --extensions ts ./ && deno test --allow-read --parallel && deno publish --dry-run && deno lint",
+        "test": "rm -rf ./docs/.vitepress/dist && rm -rf ./docs/.vitepress/cache && deno run -A npm:madge --circular --extensions ts ./ && deno test --allow-read --parallel && deno publish --dry-run --allow-dirty && deno lint && deno task docs-build",
         "typedoc": "deno run --allow-read --allow-write --allow-env --allow-run ./create-docs.ts",
         "vitepress-dev": "deno run -A npm:vitepress dev docs",
         "vitepress-build": "deno run -A npm:vitepress build docs",
@@ -35,7 +35,7 @@
         }
     },
     "name": "@yaksok-ts/core",
-    "version": "0.2.0-alpha.1+20241117",
+    "version": "0.2.0-alpha.2+20241118",
     "exports": "./src/mod.ts",
     "nodeModulesDir": "auto",
     "workspace": [

--- a/quickjs/deno.json
+++ b/quickjs/deno.json
@@ -5,5 +5,5 @@
         "quickjs-emscripten": "npm:quickjs-emscripten@^0.31.0",
         "quickjs-emscripten-core": "npm:quickjs-emscripten-core@^0.31.0"
     },
-    "version": "0.2.0-alpha.1+20241117"
+    "version": "0.2.0-alpha.2+20241118"
 }

--- a/src/error/mention.ts
+++ b/src/error/mention.ts
@@ -1,7 +1,9 @@
 import type { Position } from '../type/position.ts'
 import { YaksokError, blue, bold } from './common.ts'
 
-export class ErrorInModuleError extends YaksokError {
+export class ErrorInModuleError extends YaksokError<{
+    fileName: string
+}> {
     constructor(props: {
         position?: Position
         resource: {

--- a/src/error/prepare.ts
+++ b/src/error/prepare.ts
@@ -1,7 +1,7 @@
 import { Node } from '../node/base.ts'
 import { Token } from '../prepare/tokenize/token.ts'
 import type { Position } from '../type/position.ts'
-import { YaksokError, bold, dim } from './common.ts'
+import { YaksokError, blue, bold, dim } from './common.ts'
 
 export class CannotParseError extends YaksokError {
     constructor(props: {
@@ -107,7 +107,9 @@ export class UnexpectedTokenError extends YaksokError {
     }
 }
 
-export class FileForRunNotExistError extends YaksokError {
+export class FileForRunNotExistError extends YaksokError<{
+    fileName: string
+}> {
     constructor(props: {
         resource: {
             fileName: string
@@ -121,7 +123,7 @@ export class FileForRunNotExistError extends YaksokError {
         } else {
             this.message = `주어진 코드(${dim(
                 props.resource.files.join(', '),
-            )})에서 ${bold(
+            )})에서 ${blue(
                 `"${props.resource.fileName}"`,
             )} 파일을 찾을 수 없어요. `
         }

--- a/src/prepare/parse/dynamicRule/mention/get-exported-rules.ts
+++ b/src/prepare/parse/dynamicRule/mention/get-exported-rules.ts
@@ -1,5 +1,6 @@
 import { YaksokError } from '../../../../error/common.ts'
 import { ErrorInModuleError } from '../../../../error/mention.ts'
+import { FileForRunNotExistError } from '../../../../error/prepare.ts'
 import type { Runtime } from '../../../../runtime/index.ts'
 import { createMentioningRule } from './create-mentioning-rules.ts'
 
@@ -15,7 +16,10 @@ export function getExportedRules(runtime: Runtime, fileName: string) {
 
         return mentioningRules
     } catch (e) {
-        if (e instanceof YaksokError) {
+        if (
+            e instanceof YaksokError &&
+            !(e instanceof FileForRunNotExistError)
+        ) {
             throw new ErrorInModuleError({
                 resource: {
                     fileName,
@@ -23,5 +27,7 @@ export function getExportedRules(runtime: Runtime, fileName: string) {
                 child: e,
             })
         }
+
+        throw e
     }
 }

--- a/src/prepare/parse/dynamicRule/mention/get-exported-rules.ts
+++ b/src/prepare/parse/dynamicRule/mention/get-exported-rules.ts
@@ -1,14 +1,27 @@
+import { YaksokError } from '../../../../error/common.ts'
+import { ErrorInModuleError } from '../../../../error/mention.ts'
 import type { Runtime } from '../../../../runtime/index.ts'
 import { createMentioningRule } from './create-mentioning-rules.ts'
 
 export function getExportedRules(runtime: Runtime, fileName: string) {
-    const runner = runtime.getCodeFile(fileName)
+    try {
+        const runner = runtime.getCodeFile(fileName)
 
-    const rules = runner.exportedRules
+        const rules = runner.exportedRules
 
-    const mentioningRules = rules
-        .filter((rule) => rule.config?.exported)
-        .map((rule) => createMentioningRule(fileName, rule))
+        const mentioningRules = rules
+            .filter((rule) => rule.config?.exported)
+            .map((rule) => createMentioningRule(fileName, rule))
 
-    return mentioningRules
+        return mentioningRules
+    } catch (e) {
+        if (e instanceof YaksokError) {
+            throw new ErrorInModuleError({
+                resource: {
+                    fileName,
+                },
+                child: e,
+            })
+        }
+    }
 }

--- a/src/prepare/parse/dynamicRule/mention/index.ts
+++ b/src/prepare/parse/dynamicRule/mention/index.ts
@@ -2,6 +2,8 @@ import { getMentioningFiles } from './mentioning-files.ts'
 import { getExportedRules } from './get-exported-rules.ts'
 
 import type { CodeFile } from '../../../../type/code-file.ts'
+import { ErrorInModuleError } from '../../../../error/mention.ts'
+import { TOKEN_TYPE } from '../../../tokenize/token.ts'
 
 export function getRulesFromMentioningFile(codeFile: CodeFile) {
     if (!codeFile.mounted) {
@@ -12,9 +14,30 @@ export function getRulesFromMentioningFile(codeFile: CodeFile) {
         return []
     }
 
-    const rules = getMentioningFiles(codeFile.tokens).flatMap((fileName) =>
-        getExportedRules(codeFile.runtime!, fileName),
-    )
+    try {
+        const rules = getMentioningFiles(codeFile.tokens).flatMap((fileName) =>
+            getExportedRules(codeFile.runtime!, fileName),
+        )
 
-    return rules
+        return rules
+    } catch (e) {
+        if (e instanceof ErrorInModuleError && !e.position) {
+            const targetFileName = e.resource?.fileName
+            if (!targetFileName) throw e
+
+            const firstMentioning = codeFile.tokens.find(
+                (token) =>
+                    token.type === TOKEN_TYPE.MENTION &&
+                    token.value === '@' + targetFileName,
+            )
+
+            if (!firstMentioning) throw e
+
+            e.position = {
+                ...firstMentioning.position,
+            }
+        }
+
+        throw e
+    }
 }

--- a/src/prepare/parse/dynamicRule/mention/index.ts
+++ b/src/prepare/parse/dynamicRule/mention/index.ts
@@ -4,8 +4,10 @@ import { getExportedRules } from './get-exported-rules.ts'
 import type { CodeFile } from '../../../../type/code-file.ts'
 import { ErrorInModuleError } from '../../../../error/mention.ts'
 import { TOKEN_TYPE } from '../../../tokenize/token.ts'
+import { Rule } from '../../rule.ts'
+import { FileForRunNotExistError } from '../../../../error/prepare.ts'
 
-export function getRulesFromMentioningFile(codeFile: CodeFile) {
+export function getRulesFromMentioningFile(codeFile: CodeFile): Rule[] {
     if (!codeFile.mounted) {
         console.warn(
             'CodeFile is not mounted to Runtime, skips mentioning files',
@@ -21,7 +23,11 @@ export function getRulesFromMentioningFile(codeFile: CodeFile) {
 
         return rules
     } catch (e) {
-        if (e instanceof ErrorInModuleError && !e.position) {
+        if (
+            (e instanceof ErrorInModuleError ||
+                e instanceof FileForRunNotExistError) &&
+            !e.position
+        ) {
             const targetFileName = e.resource?.fileName
             if (!targetFileName) throw e
 

--- a/src/type/code-file.ts
+++ b/src/type/code-file.ts
@@ -2,6 +2,7 @@ import { getFunctionDeclareRanges } from '../util/get-function-declare-ranges.ts
 import { executer, type ExecuteResult } from '../executer/index.ts'
 import { tokenize } from '../prepare/tokenize/index.ts'
 import { parse } from '../prepare/parse/index.ts'
+import { YaksokError } from '../error/common.ts'
 
 import type { Token } from '../prepare/tokenize/token.ts'
 import type { Rule } from '../prepare/parse/rule.ts'
@@ -55,11 +56,19 @@ export class CodeFile {
     }
 
     public get exportedRules(): Rule[] {
-        if (!this.exportedRulesCache) {
-            this.parse()
-        }
+        try {
+            if (!this.exportedRulesCache) {
+                this.parse()
+            }
 
-        return this.exportedRulesCache as Rule[]
+            return this.exportedRulesCache as Rule[]
+        } catch (e) {
+            if (e instanceof YaksokError && !e.codeFile) {
+                e.codeFile = this
+            }
+
+            throw e
+        }
     }
 
     private parse() {


### PR DESCRIPTION
불러오기 문법을 파싱하는 중 다른 약속에서 발생한 오류에 CodeFile을 올바르게 부착하고 ErrorsInModule로 감싸서 올바르게 오류가 표시될 수 있도록 합니다.

```
─────

🚨  문제가 발생했어요 (맹봇 파일) 🚨
46번째 줄의 10번째 글자

> "줄넘김"가 나와야 했지만 코드가 끝났어요.

┌─────
│  45  
│  46  약속, (문장) 말하기
│                 ^
└─────

─────

🚨  문제가 발생했어요 (main 파일) 🚨
1번째 줄의 1번째 글자

> 다른 약속 파일 맹봇에서 오류가 발생했어요.

┌─────
│  1  @맹봇 1초 동안 20도 회전하기
│        ^
└─────
```