### PR TITLE
Fix: get quickjs wasm binary from unpkg at runtime

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -34,7 +34,7 @@
         }
     },
     "name": "@yaksok-ts/core",
-    "version": "0.1.18-alpha.1",
+    "version": "0.1.18-alpha.2",
     "exports": "./src/mod.ts",
     "nodeModulesDir": "auto",
     "workspace": [

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,6 @@
 {
     "imports": {
+        "@jitl/quickjs-ng-wasmfile-release-sync": "npm:@jitl/quickjs-ng-wasmfile-release-sync@^0.31.0",
         "@vue/runtime-dom": "npm:@vue/runtime-dom@^3.5.12",
         "@vueuse/core": "npm:@vueuse/core@^11.2.0",
         "ansi-to-html": "npm:ansi-to-html@^0.7.2",
@@ -33,7 +34,7 @@
         }
     },
     "name": "@yaksok-ts/core",
-    "version": "0.1.17",
+    "version": "0.1.18-alpha.1",
     "exports": "./src/mod.ts",
     "nodeModulesDir": "auto",
     "workspace": [

--- a/deno.json
+++ b/deno.json
@@ -15,7 +15,7 @@
     "tasks": {
         "coverage": "rm -rf ./cov && deno test --allow-read --parallel --coverage=cov && deno coverage --detailed ./cov && rm -rf ./cov",
         "coverage-list": "rm -rf ./cov && deno test --allow-read --parallel --coverage=cov && deno coverage ./cov && rm -rf ./cov",
-        "test": "deno run -A npm:madge --circular --extensions ts ./ && deno test --allow-read --parallel && deno publish --dry-run",
+        "test": "deno run -A npm:madge --circular --extensions ts ./ && deno test --allow-read --allow-net --parallel && deno publish --dry-run",
         "typedoc": "deno run --allow-read --allow-write --allow-env --allow-run ./create-docs.ts",
         "vitepress-dev": "deno run -A npm:vitepress dev docs",
         "vitepress-build": "deno run -A npm:vitepress build docs",

--- a/deno.json
+++ b/deno.json
@@ -34,7 +34,7 @@
         }
     },
     "name": "@yaksok-ts/core",
-    "version": "0.1.18-alpha.2",
+    "version": "0.1.18-alpha.3",
     "exports": "./src/mod.ts",
     "nodeModulesDir": "auto",
     "workspace": [

--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,9 @@
   "specifiers": {
     "jsr:@std/assert@^1.0.7": "1.0.7",
     "jsr:@std/internal@^1.0.5": "1.0.5",
+    "npm:@jitl/quickjs-ng-wasmfile-release-sync@*": "0.31.0",
+    "npm:@jitl/quickjs-ng-wasmfile-release-sync@0.31": "0.31.0",
+    "npm:@jitl/quickjs-wasmfile-release-sync@0.31": "0.31.0",
     "npm:@vue/runtime-dom@^3.5.12": "3.5.12",
     "npm:@vueuse/core@^11.2.0": "11.2.0_vue@3.5.12",
     "npm:ansi-to-html@~0.7.2": "0.7.2",
@@ -296,6 +299,12 @@
     },
     "@jitl/quickjs-ffi-types@0.31.0": {
       "integrity": "sha512-1yrgvXlmXH2oNj3eFTrkwacGJbmM0crwipA3ohCrjv52gBeDaD7PsTvFYinlAnqU8iPME3LGP437yk05a2oejw=="
+    },
+    "@jitl/quickjs-ng-wasmfile-release-sync@0.31.0": {
+      "integrity": "sha512-D99G2Re2e4GmJM0NZIALmp0kwb1upUYbhlA6bTdwSSzMBovh+Elagfe2bGgR9pUsqeH/hDD913TRERQi077iqA==",
+      "dependencies": [
+        "@jitl/quickjs-ffi-types"
+      ]
     },
     "@jitl/quickjs-wasmfile-debug-asyncify@0.31.0": {
       "integrity": "sha512-YkdzQdr1uaftFhgEnTRjTTZHk2SFZdpWO7XhOmRVbi6CEVsH9g5oNF8Ta1q3OuSJHRwwT8YsuR1YzEiEIJEk6w==",
@@ -2016,6 +2025,7 @@
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@^1.0.7",
+      "npm:@jitl/quickjs-ng-wasmfile-release-sync@0.31",
       "npm:@vue/runtime-dom@^3.5.12",
       "npm:@vueuse/core@^11.2.0",
       "npm:ansi-to-html@~0.7.2",

--- a/quickjs/deno.json
+++ b/quickjs/deno.json
@@ -5,5 +5,5 @@
         "quickjs-emscripten": "npm:quickjs-emscripten@^0.31.0",
         "quickjs-emscripten-core": "npm:quickjs-emscripten-core@^0.31.0"
     },
-    "version": "0.1.18-alpha.1"
+    "version": "0.1.18-alpha.2"
 }

--- a/quickjs/deno.json
+++ b/quickjs/deno.json
@@ -5,5 +5,5 @@
         "quickjs-emscripten": "npm:quickjs-emscripten@^0.31.0",
         "quickjs-emscripten-core": "npm:quickjs-emscripten-core@^0.31.0"
     },
-    "version": "0.1.18-alpha.2"
+    "version": "0.1.18-alpha.3"
 }

--- a/quickjs/deno.json
+++ b/quickjs/deno.json
@@ -5,5 +5,5 @@
         "quickjs-emscripten": "npm:quickjs-emscripten@^0.31.0",
         "quickjs-emscripten-core": "npm:quickjs-emscripten-core@^0.31.0"
     },
-    "version": "0.1.17"
+    "version": "0.1.18-alpha.1"
 }

--- a/quickjs/mod.ts
+++ b/quickjs/mod.ts
@@ -1,5 +1,6 @@
-import { getQuickJS } from 'quickjs-emscripten'
 import type { QuickJSWASMModule, QuickJSContext } from 'quickjs-emscripten-core'
+import { newQuickJSWASMModuleFromVariant } from 'quickjs-emscripten'
+import quickJSVariant from '@jitl/quickjs-ng-wasmfile-release-sync'
 
 import {
     List,
@@ -19,7 +20,9 @@ export class QuickJS {
     ) {}
 
     async init(): Promise<void> {
-        this.instance = await getQuickJS()
+        this.instance = await newQuickJSWASMModuleFromVariant(
+            Promise.resolve(quickJSVariant),
+        )
     }
 
     public run(bodyCode: string, args: FunctionParams): ValueTypes {

--- a/quickjs/mod.ts
+++ b/quickjs/mod.ts
@@ -1,6 +1,18 @@
 import type { QuickJSWASMModule, QuickJSContext } from 'quickjs-emscripten-core'
-import { newQuickJSWASMModuleFromVariant } from 'quickjs-emscripten'
-import quickJSVariant from '@jitl/quickjs-ng-wasmfile-release-sync'
+import {
+    newQuickJSWASMModuleFromVariant,
+    RELEASE_SYNC,
+    newVariant,
+} from 'quickjs-emscripten'
+
+const wasmPath =
+    'https://unpkg.com/@jitl/quickjs-wasmfile-release-sync@0.31.0/dist/emscripten-module.wasm'
+
+const wasmModule = await WebAssembly.compileStreaming(fetch(wasmPath))
+
+const variant = newVariant(RELEASE_SYNC, {
+    wasmModule,
+})
 
 import {
     List,
@@ -20,9 +32,7 @@ export class QuickJS {
     ) {}
 
     async init(): Promise<void> {
-        this.instance = await newQuickJSWASMModuleFromVariant(
-            Promise.resolve(quickJSVariant),
-        )
+        this.instance = await newQuickJSWASMModuleFromVariant(variant)
     }
 
     public run(bodyCode: string, args: FunctionParams): ValueTypes {

--- a/quickjs/mod.ts
+++ b/quickjs/mod.ts
@@ -5,15 +5,6 @@ import {
     newVariant,
 } from 'quickjs-emscripten'
 
-const wasmPath =
-    'https://unpkg.com/@jitl/quickjs-wasmfile-release-sync@0.31.0/dist/emscripten-module.wasm'
-
-const wasmModule = await WebAssembly.compileStreaming(fetch(wasmPath))
-
-const variant = newVariant(RELEASE_SYNC, {
-    wasmModule,
-})
-
 import {
     List,
     NumberValue,
@@ -32,6 +23,15 @@ export class QuickJS {
     ) {}
 
     async init(): Promise<void> {
+        const wasmPath =
+            'https://unpkg.com/@jitl/quickjs-wasmfile-release-sync@0.31.0/dist/emscripten-module.wasm'
+
+        const wasmModule = await WebAssembly.compileStreaming(fetch(wasmPath))
+
+        const variant = newVariant(RELEASE_SYNC, {
+            wasmModule,
+        })
+
         this.instance = await newQuickJSWASMModuleFromVariant(variant)
     }
 

--- a/quickjs/quickjs.test.ts
+++ b/quickjs/quickjs.test.ts
@@ -32,37 +32,6 @@ Deno.test('Error in QuickJS', async () => {
     }
 })
 
-Deno.test('Not initialized yet', () => {
-    const quickJS = new QuickJS()
-    quickJS.init()
-
-    try {
-        yaksok(
-            `
-번역(QuickJS), 에러 발생
-***
-    throw new Error('QuickJS Error')
-***
-
-에러 발생`,
-            {
-                runFFI(_, code, args) {
-                    const result = quickJS.run(code, args)
-
-                    if (!result) {
-                        throw new Error('Result is null')
-                    }
-
-                    return result
-                },
-            },
-        )
-    } catch (error) {
-        assertIsError(error)
-        assertEquals(error.message, 'QuickJS instance is not initialized yet')
-    }
-})
-
 Deno.test('QuickJS passed number', async () => {
     const quickJS = new QuickJS()
     await quickJS.init()

--- a/runtest.ts
+++ b/runtest.ts
@@ -1,38 +1,25 @@
-import { yaksok } from './src/mod.ts'
+import { QuickJS } from '@yaksok-ts/quickjs'
+import { yaksok } from '@yaksok-ts/core'
+
+const quickjs = new QuickJS({
+    prompt,
+})
+await quickjs.init()
 
 yaksok(
     `
-약속, 회전설정 (회전)
-    결과: "rotate:" + 회전
+번역(QuickJS), (질문) 물어보기
+***
+    return prompt(질문)
+***
 
-약속, 시간설정 (시간)
-    결과: "time:" + 시간
-
-약속, (A) 합 (B)
-    결과: A + "<join>" + B
-
-약속, (각도)도 회전하기
-    회전설정 각도 보여주기
-
-약속, (시간)초 동안 (각도)도 회전하기
-    (시간설정 시간) 합 (회전설정 각도) 보여주기
-
-각도: 45
-시간: 30
-
-(3)초 동안 (90)도 회전하기
-3 초 동안 90 도 회전하기
-(3)초 동안 90 도 회전하기
-3 초 동안 (90)도 회전하기
-
-시간 초 동안 각도 도 회전하기
-(시간)초 동안 (각도)도 회전하기
-(시간)초 동안 각도 도 회전하기
-시간 초 동안 (각도)도 회전하기
-
-(90)도 회전하기
-90 도 회전하기
-각도 도 회전하기
-(각도)도 회전하기
+입력받은_이름: "이름이 뭐에요?" 물어보기
+입력받은_이름 + "님 안녕하세요!" 보여주기
 `,
+    {
+        runFFI(r, code, args) {
+            const result = quickjs.run(code, args)
+            return result
+        },
+    },
 )


### PR DESCRIPTION
일부 번들링 환경에서 WASM 파일을 받아오는 과정에서 오류가 발생하여, 런타임에 wasm 파일을 패키지 URL로부터 직접 로드하도록 수정하였습니다. Vite, Deno 환경에서 올바르게 작동합니다.